### PR TITLE
feat: req.param transform

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -9,9 +9,9 @@ export const TRANSFORM_OPTIONS = [
     value: 'pluralized-methods',
     version: '5.0.0',
   },
-  { 
-    description: 'Transform the deprecated signatures in Express v4', 
-    value: 'v4-deprecated-signatures', 
-    version: '5.0.0'
+  {
+    description: 'Transform the deprecated signatures in Express v4',
+    value: 'v4-deprecated-signatures',
+    version: '5.0.0',
   },
 ]

--- a/transforms/__test__/req-param.spec.ts
+++ b/transforms/__test__/req-param.spec.ts
@@ -1,0 +1,3 @@
+import { testSpecBuilder } from './util'
+
+testSpecBuilder('req-param')

--- a/transforms/__testfixtures__/req-param/req-param.input.ts
+++ b/transforms/__testfixtures__/req-param/req-param.input.ts
@@ -5,25 +5,33 @@ const app = express();
 app.get("/", function (req, res) {
   const reqBody = req.param('body');
   const reqQuery = req.param('query');
+  const reqQueryTest = req.param('query').test;
   const reqOther = req.param('other');
+  const reqOtherNested = req.param('other').nested;
 });
 
 app.get("/", function (request, response) {
   const reqBody = request.param('body');
   const reqQuery = request.param('query');
+  const reqQueryTest = request.param('query').test;
   const reqOther = request.param('other');
+  const reqOtherNested = request.param('other').nested;
 });
 
 app.get("/", (req, res) => {
   const reqBody = req.param('body');
   const reqQuery = req.param('query');
+  const reqQueryTest = req.param('query').test;
   const reqOther = req.param('other');
+  const reqOtherNested = req.param('other').nested;
 });
 
 app.get("/", (request, response) => {
   const reqBody = request.param('body');
   const reqQuery = request.param('query');
+  const reqQueryTest = request.param('query').test;
   const reqOther = request.param('other');
+  const reqOtherNested = request.param('other').nested;
 });
 
 app.param(function () {

--- a/transforms/__testfixtures__/req-param/req-param.input.ts
+++ b/transforms/__testfixtures__/req-param/req-param.input.ts
@@ -1,0 +1,31 @@
+import express from "express";
+
+const app = express();
+
+app.get("/", function (req, res) {
+  const reqBody = req.param('body');
+  const reqQuery = req.param('query');
+  const reqOther = req.param('other');
+});
+
+app.get("/", function (request, response) {
+  const reqBody = request.param('body');
+  const reqQuery = request.param('query');
+  const reqOther = request.param('other');
+});
+
+app.get("/", (req, res) => {
+  const reqBody = req.param('body');
+  const reqQuery = req.param('query');
+  const reqOther = req.param('other');
+});
+
+app.get("/", (request, response) => {
+  const reqBody = request.param('body');
+  const reqQuery = request.param('query');
+  const reqOther = request.param('other');
+});
+
+app.param(function () {
+    // my important logic
+})

--- a/transforms/__testfixtures__/req-param/req-param.output.ts
+++ b/transforms/__testfixtures__/req-param/req-param.output.ts
@@ -5,25 +5,33 @@ const app = express();
 app.get("/", function (req, res) {
   const reqBody = req.body;
   const reqQuery = req.query;
+  const reqQueryTest = req.query.test;
   const reqOther = req.params.other;
+  const reqOtherNested = req.params.other.nested;
 });
 
 app.get("/", function (request, response) {
   const reqBody = request.body;
   const reqQuery = request.query;
+  const reqQueryTest = request.query.test;
   const reqOther = request.params.other;
+  const reqOtherNested = request.params.other.nested;
 });
 
 app.get("/", (req, res) => {
   const reqBody = req.body;
   const reqQuery = req.query;
+  const reqQueryTest = req.query.test;
   const reqOther = req.params.other;
+  const reqOtherNested = req.params.other.nested;
 });
 
 app.get("/", (request, response) => {
   const reqBody = request.body;
   const reqQuery = request.query;
+  const reqQueryTest = request.query.test;
   const reqOther = request.params.other;
+  const reqOtherNested = request.params.other.nested;
 });
 
 app.param(function () {

--- a/transforms/__testfixtures__/req-param/req-param.output.ts
+++ b/transforms/__testfixtures__/req-param/req-param.output.ts
@@ -1,0 +1,31 @@
+import express from "express";
+
+const app = express();
+
+app.get("/", function (req, res) {
+  const reqBody = req.body;
+  const reqQuery = req.query;
+  const reqOther = req.params.other;
+});
+
+app.get("/", function (request, response) {
+  const reqBody = request.body;
+  const reqQuery = request.query;
+  const reqOther = request.params.other;
+});
+
+app.get("/", (req, res) => {
+  const reqBody = req.body;
+  const reqQuery = req.query;
+  const reqOther = req.params.other;
+});
+
+app.get("/", (request, response) => {
+  const reqBody = request.body;
+  const reqQuery = request.query;
+  const reqOther = request.params.other;
+});
+
+app.param(function () {
+    // my important logic
+})

--- a/transforms/app-param.ts
+++ b/transforms/app-param.ts
@@ -9,11 +9,11 @@ export default function transformer(file: FileInfo, _api: API): string {
       .find(CallExpression, {
         callee: {
           property: {
-            name: 'json',
+            name: 'param',
           },
         },
       })
-      // TODO: app.param(fn): This method has been deprecated. Instead, access parameters directly via req.params, or use req.body or req.query as needed.
+      // TODO: The app.param(fn) signature was used for modifying the behavior of the app.param(name, fn) function
       // Add comment line before with this information
       .toSource()
   )

--- a/transforms/req-param.ts
+++ b/transforms/req-param.ts
@@ -1,0 +1,43 @@
+import type { API, FileInfo } from 'jscodeshift'
+import { CallExpression, memberExpression, withParser } from 'jscodeshift'
+import { recursiveParent } from '../utils/recursiveParent'
+
+export default function transformer(file: FileInfo, _api: API): string {
+  const parser = withParser('ts')
+
+  return (
+    parser(file.source)
+      .find(CallExpression, {
+        callee: {
+          property: {
+            name: 'param',
+          },
+        },
+      })
+      .filter((path) => Boolean(recursiveParent(path.parentPath)))
+      .map((path) => {
+        console.log(path.node.arguments)
+        const pathArguments = path.node.arguments
+
+        if (pathArguments.length > 1) {
+          return path
+        }
+
+        if (pathArguments[0].type === 'StringLiteral') {
+          if (pathArguments[0].value === 'query') {
+            // convert to req.query
+            return memberExpression()
+          }
+          if (pathArguments[0].value === 'body') {
+            // convert to req.body
+            return memberExpression()
+          }
+
+          // convert to req.params.[value]
+          return memberExpression()
+        }
+      })
+      // TODO: req.param(name): This method has been deprecated. Instead, access parameters directly via req.params, or use req.body or req.query as needed.
+      .toSource()
+  )
+}

--- a/transforms/req-param.ts
+++ b/transforms/req-param.ts
@@ -1,43 +1,44 @@
 import type { API, FileInfo } from 'jscodeshift'
-import { CallExpression, memberExpression, withParser } from 'jscodeshift'
+import { CallExpression, identifier, memberExpression, withParser } from 'jscodeshift'
 import { recursiveParent } from '../utils/recursiveParent'
 
 export default function transformer(file: FileInfo, _api: API): string {
   const parser = withParser('ts')
 
-  return (
-    parser(file.source)
-      .find(CallExpression, {
-        callee: {
-          property: {
-            name: 'param',
-          },
+  return parser(file.source)
+    .find(CallExpression, {
+      callee: {
+        property: {
+          name: 'param',
         },
-      })
-      .filter((path) => Boolean(recursiveParent(path.parentPath)))
-      .map((path) => {
-        console.log(path.node.arguments)
-        const pathArguments = path.node.arguments
+      },
+    })
+    .filter((path) => Boolean(recursiveParent(path.parentPath)))
+    .replaceWith((path) => {
+      const pathArguments = path.node.arguments
 
-        if (pathArguments.length > 1) {
-          return path
+      if (pathArguments.length > 1) {
+        return path
+      }
+
+      if (pathArguments[0].type === 'StringLiteral') {
+        if (pathArguments[0].value === 'query') {
+          // convert to req.query
+          return memberExpression(identifier(recursiveParent(path.parentPath) || 'req'), identifier('query'))
+        }
+        if (pathArguments[0].value === 'body') {
+          // convert to req.body
+          return memberExpression(identifier(recursiveParent(path.parentPath) || 'req'), identifier('body'))
         }
 
-        if (pathArguments[0].type === 'StringLiteral') {
-          if (pathArguments[0].value === 'query') {
-            // convert to req.query
-            return memberExpression()
-          }
-          if (pathArguments[0].value === 'body') {
-            // convert to req.body
-            return memberExpression()
-          }
+        // convert to req.params.[value]
+        return memberExpression(
+          memberExpression(identifier(recursiveParent(path.parentPath) || 'req'), identifier('params')),
+          identifier(pathArguments[0].value),
+        )
+      }
 
-          // convert to req.params.[value]
-          return memberExpression()
-        }
-      })
-      // TODO: req.param(name): This method has been deprecated. Instead, access parameters directly via req.params, or use req.body or req.query as needed.
-      .toSource()
-  )
+      return path
+    })
+    .toSource()
 }


### PR DESCRIPTION
In v3 it's possible to do this:
```
req.param('query')
req.param('name') // custom param
req.param('body')
```

source: https://expressjs.com/en/3x/api.html#req.param

in v4 it's deprecated: https://expressjs.com/en/4x/api.html#req.param

in v5 it's no longer available. Instead, you have to use:
- https://expressjs.com/en/5x/api.html#req.params
- https://expressjs.com/en/5x/api.html#req.query
- https://expressjs.com/en/5x/api.html#req.body

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->