### PR TITLE
feat: add upgrade command

### DIFF
--- a/commands/__test__/upgrade.spec.ts
+++ b/commands/__test__/upgrade.spec.ts
@@ -1,0 +1,29 @@
+import { run } from 'jscodeshift/src/Runner'
+import { upgrade } from '../upgrade'
+
+jest.mock('jscodeshift/src/Runner', () => ({
+  run: jest.fn(),
+}))
+
+describe('interactive mode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it.todo('runs without source params provided and select is true')
+})
+
+describe('Non-Interactive Mode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('Transforms code with source params provided', async () => {
+    const spyOnConsole = jest.spyOn(console, 'log').mockImplementation()
+
+    await upgrade('__testfixtures__')
+
+    expect(spyOnConsole).toHaveBeenCalled()
+    expect(run).toHaveBeenCalledTimes(4)
+  })
+})

--- a/commands/__test__/upgrade.spec.ts
+++ b/commands/__test__/upgrade.spec.ts
@@ -1,4 +1,5 @@
 import { run } from 'jscodeshift/src/Runner'
+import prompts from 'prompts'
 import { upgrade } from '../upgrade'
 
 jest.mock('jscodeshift/src/Runner', () => ({
@@ -10,7 +11,41 @@ describe('interactive mode', () => {
     jest.clearAllMocks()
   })
 
-  it.todo('runs without source params provided and select is true')
+  it('runs without source params provided and select is true', async () => {
+    const spyOnConsole = jest.spyOn(console, 'log').mockImplementation()
+
+    prompts.inject([['magic-redirect', 'req-param']])
+
+    await upgrade('__testfixtures__', { select: true })
+
+    expect(spyOnConsole).toHaveBeenCalled()
+    expect(spyOnConsole).toHaveBeenCalledTimes(3)
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs with source params provided and select is true', async () => {
+    const spyOnConsole = jest.spyOn(console, 'log').mockImplementation()
+
+    prompts.inject([['magic-redirect', 'req-param']])
+
+    await upgrade('__testfixtures__', { select: true })
+
+    expect(spyOnConsole).toHaveBeenCalled()
+    expect(spyOnConsole).toHaveBeenCalledTimes(3)
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs without source params provided and select is undefined', async () => {
+    const spyOnConsole = jest.spyOn(console, 'log').mockImplementation()
+
+    prompts.inject(['__testfixtures__'])
+
+    await upgrade(undefined)
+
+    expect(spyOnConsole).toHaveBeenCalled()
+    expect(spyOnConsole).toHaveBeenCalledTimes(5)
+    expect(run).toHaveBeenCalledTimes(4)
+  })
 })
 
 describe('Non-Interactive Mode', () => {
@@ -24,6 +59,8 @@ describe('Non-Interactive Mode', () => {
     await upgrade('__testfixtures__')
 
     expect(spyOnConsole).toHaveBeenCalled()
+    expect(spyOnConsole).toHaveBeenCalledTimes(5)
+    expect(spyOnConsole).toHaveBeenLastCalledWith('\n> All codemods have been applied successfully. \n')
     expect(run).toHaveBeenCalledTimes(4)
   })
 })

--- a/commands/__test__/upgrade.spec.ts
+++ b/commands/__test__/upgrade.spec.ts
@@ -58,8 +58,11 @@ describe('Non-Interactive Mode', () => {
 
     await upgrade('__testfixtures__')
 
-    expect(spyOnConsole).toHaveBeenCalled()
     expect(spyOnConsole).toHaveBeenCalledTimes(5)
+    expect(spyOnConsole).toHaveBeenCalledWith('> Applying codemod: magic-redirect')
+    expect(spyOnConsole).toHaveBeenCalledWith('> Applying codemod: pluralized-methods')
+    expect(spyOnConsole).toHaveBeenCalledWith('> Applying codemod: req-param')
+    expect(spyOnConsole).toHaveBeenCalledWith('> Applying codemod: v4-deprecated-signatures')
     expect(spyOnConsole).toHaveBeenLastCalledWith('\n> All codemods have been applied successfully. \n')
     expect(run).toHaveBeenCalledTimes(4)
   })

--- a/commands/transform.ts
+++ b/commands/transform.ts
@@ -4,11 +4,7 @@ import { run as jscodeshift } from 'jscodeshift/src/Runner'
 import { bold } from 'picocolors'
 import prompts from 'prompts'
 import { TRANSFORM_OPTIONS } from '../config'
-
-export function onCancel() {
-  console.info('> Cancelled process. Program will stop now without any actions. \n')
-  process.exit(1)
-}
+import { onCancel, promptSource } from '../utils/prompts'
 
 const transformerDirectory = join(__dirname, '../', 'transforms')
 
@@ -32,20 +28,6 @@ const selectCodemod = async (): Promise<string> => {
   return res.transformer
 }
 
-const selectSource = async (): Promise<string> => {
-  const res = await prompts(
-    {
-      type: 'text',
-      name: 'path',
-      message: 'Which files or directories should the codemods be applied to?',
-      initial: '.',
-    },
-    { onCancel },
-  )
-
-  return res.path
-}
-
 export async function transform(codemodName?: string, source?: string, options?: Record<string, unknown>) {
   const existCodemod = TRANSFORM_OPTIONS.find(({ value }) => value === codemodName)
   const codemodSelected = !codemodName || (codemodName && !existCodemod) ? await selectCodemod() : codemodName
@@ -55,7 +37,7 @@ export async function transform(codemodName?: string, source?: string, options?:
     process.exit(1)
   }
 
-  const sourceSelected = source || (await selectSource())
+  const sourceSelected = source || (await promptSource('Which files or directories should the codemods be applied to?'))
 
   if (!sourceSelected) {
     console.info('> Source path for project is not selected. Exits the program. \n')

--- a/commands/upgrade.ts
+++ b/commands/upgrade.ts
@@ -1,0 +1,63 @@
+import { join, resolve } from 'node:path'
+import type { Options } from 'jscodeshift'
+import { run as jscodeshift } from 'jscodeshift/src/Runner'
+import prompts from 'prompts'
+import { TRANSFORM_OPTIONS } from '../config'
+import { onCancel, promptSource } from '../utils/prompts'
+
+const transformerDirectory = join(__dirname, '../', 'transforms')
+
+export async function upgrade(source?: string, options?: Record<string, unknown>) {
+  const sourceSelected = source || (await promptSource('Which directory should the codemods be applied to?'))
+
+  if (!sourceSelected) {
+    console.info('> Source path for project is not selected. Exits the program. \n')
+    process.exit(1)
+  }
+  let codemods: string[] = []
+
+  if (options?.select) {
+    const { codemodsSelected } = await prompts(
+      {
+        type: 'multiselect',
+        name: 'codemodsSelected',
+        message: `The following 'codemods' are recommended for your upgrade. Select the ones to apply.`,
+        choices: TRANSFORM_OPTIONS.map(({ description, value, version }) => {
+          return {
+            title: `(v${version}) ${value}`,
+            description,
+            value,
+            selected: true,
+          }
+        }),
+      },
+      { onCancel },
+    )
+    codemods = codemodsSelected
+  } else {
+    codemods = TRANSFORM_OPTIONS.map(({ value }) => value)
+  }
+
+  const args: Options = {
+    dry: false,
+    babel: false,
+    silent: true,
+    ignorePattern: '**/node_modules/**',
+    extensions: 'cts,mts,ts,js,mjs,cjs',
+  }
+
+  for (const codemod of codemods) {
+    const transformerPath = join(transformerDirectory, `${codemod}.js`)
+
+    console.log(`> Applying codemod: ${codemod}`)
+
+    try {
+      await jscodeshift(transformerPath, [resolve(sourceSelected)], args)
+    } catch (error) {
+      console.error(`> Error applying codemod: ${codemod}`)
+      console.error(error)
+    }
+  }
+
+  console.log('\n> All codemods have been applied successfully. \n')
+}

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@
 
 import { Command } from 'commander'
 import { transform } from './commands/transform'
+import { upgrade } from './commands/upgrade'
 import packageJson from './package.json'
 
 const program = new Command(packageJson.name)
@@ -21,5 +22,12 @@ const program = new Command(packageJson.name)
   .action(transform)
   // Why this option is necessary is explained here: https://github.com/tj/commander.js/pull/1427
   .enablePositionalOptions()
+
+program
+  .command('upgrade')
+  .description('Upgrade your express server to the latest version.')
+  .argument('[source]', 'Path to source files or directory to transform.')
+  .option('--select', 'Select which codemods to apply (Show a list of available codemods)')
+  .action(upgrade)
 
 program.parse(process.argv)

--- a/utils/prompts.ts
+++ b/utils/prompts.ts
@@ -1,0 +1,20 @@
+import prompts from 'prompts'
+
+export function onCancel() {
+  console.info('> Cancelled process. Program will stop now without any actions. \n')
+  process.exit(1)
+}
+
+export const promptSource = async (message: string): Promise<string> => {
+  const res = await prompts(
+    {
+      type: 'text',
+      name: 'path',
+      message,
+      initial: '.',
+    },
+    { onCancel },
+  )
+
+  return res.path
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This adds the command to update Express in a single step, displaying the available options based on the version specified in the package.json.

Things still to do:

- ~~Make the jscodeshift input more user-friendly~~
- add tests