### PR TITLE
chore: add prepublishOnly scripts to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,18 +3,21 @@
   "private": true,
   "version": "0.0.1",
   "description": "Codemods for updating express servers.",
-  "main": "build/index.js",
   "contributors": ["Sebastian Beltran <bjohansebas@gmail.com>", "Filip Kudla <filip.kudla.dev@gmail.com>"],
   "license": "MIT",
-  "bin": "build/index.js",
-  "files": ["build/transforms/*.js", "build/commands/*.js", "build/utils/*.js", "build/config.js", "build/index.js"],
+  "bin": {
+    "express-codemod": "build/index.js"
+  },
+  "files": ["build/**/*.js"],
   "scripts": {
+    "clean": "rm -rf build",
     "dev": "tsc -d -w -p tsconfig.json",
     "build": "tsc -d -p tsconfig.json",
     "lint": "biome check",
     "lint:fix": "biome check --fix",
     "test": "jest",
-    "test:ci": "jest --ci"
+    "test:ci": "jest --ci",
+    "prepublishOnly": "npm run clean && npm run build"
   },
   "dependencies": {
     "commander": "^12.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "outDir": "build"
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "build", "transforms/__testfixtures__/**", "__test__", "**/*.spec.ts"]
+  "exclude": ["node_modules", "build", "**/__testfixtures__", "**/__test__", "**/*.spec.ts"]
 }


### PR DESCRIPTION
I add this command before publishing the package to clean and ensure the package is built.
![image](https://github.com/user-attachments/assets/bebcf7f4-15bc-4bc9-ba33-92b3c8aa9960)