### PR TITLE
fix: ensure arguments are reversed only if not already in correct order

### DIFF
--- a/transforms/__testfixtures__/v4-deprecated-signatures/redirect.input.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/redirect.input.ts
@@ -12,5 +12,13 @@ app.get("/", function (req, response) {
 });
 
 app.get("/", function (req, res) {
+  res.redirect(301, "/other-page");
+});
+
+app.get("/", function (req, res) {
+  res.redirect("/other-page");
+});
+
+app.get("/", function (req, res) {
   redirect(301, "/other-page");
 });

--- a/transforms/__testfixtures__/v4-deprecated-signatures/redirect.output.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/redirect.output.ts
@@ -12,5 +12,13 @@ app.get("/", function (req, response) {
 });
 
 app.get("/", function (req, res) {
+  res.redirect(301, "/other-page");
+});
+
+app.get("/", function (req, res) {
+  res.redirect("/other-page");
+});
+
+app.get("/", function (req, res) {
   redirect(301, "/other-page");
 });

--- a/transforms/v4-deprecated-signatures.ts
+++ b/transforms/v4-deprecated-signatures.ts
@@ -124,8 +124,11 @@ export default function transformer(file: FileInfo, _api: API): string {
       },
     })
     .map((path) => {
-      if (path.value.arguments.length === 2) {
-        path.value.arguments.reverse()
+      const args = path.value.arguments;
+
+      // if its already in the correct order, dont reverse
+      if (args.length === 2 && typeof args[0].type !== 'number') {
+        args.reverse();
       }
 
       return path

--- a/transforms/v4-deprecated-signatures.ts
+++ b/transforms/v4-deprecated-signatures.ts
@@ -124,11 +124,11 @@ export default function transformer(file: FileInfo, _api: API): string {
       },
     })
     .map((path) => {
-      const args = path.value.arguments;
+      const args = path.value.arguments
 
       // if its already in the correct order, dont reverse
-      if (args.length === 2 && typeof args[0].type !== 'number') {
-        args.reverse();
+      if (args.length === 2 && args[0]?.type !== 'NumericLiteral') {
+        args.reverse()
       }
 
       return path


### PR DESCRIPTION
apply twice the same codemod makes incorrect transformation for `redirect()`
