### PR TITLE
fix bug with res.del when the first arguments it's a function

### DIFF
--- a/transforms/__testfixtures__/v4-deprecated-signatures/delete.input.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/delete.input.ts
@@ -4,6 +4,18 @@ const app = express();
 
 app.get("/", (req, res) => {});
 
+app.del([""],() => {
+  myImportantLogic();
+});
+
+app.del([],() => {
+  myImportantLogic();
+});
+
+app.del(/d/,() => {
+  myImportantLogic();
+});
+
 app.del(() => {
   myImportantLogic();
 });

--- a/transforms/__testfixtures__/v4-deprecated-signatures/delete.input.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/delete.input.ts
@@ -3,6 +3,15 @@ import express from "express";
 const app = express();
 
 app.get("/", (req, res) => {});
+
+app.del(() => {
+  myImportantLogic();
+});
+
+app.del(function () {
+  myImportantLogic();
+});
+
 app.del("/old", () => {
   myImportantLogic();
 });

--- a/transforms/__testfixtures__/v4-deprecated-signatures/delete.input.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/delete.input.ts
@@ -16,6 +16,12 @@ app.del("/old", () => {
   myImportantLogic();
 });
 
+function noModify() {
+  let a
+
+  app.del(a)
+}
+
 const myImportantLogic = () => {
   console.log("making sure it's there");
 };

--- a/transforms/__testfixtures__/v4-deprecated-signatures/delete.output.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/delete.output.ts
@@ -16,6 +16,12 @@ app.delete("/old", () => {
   myImportantLogic();
 });
 
+function noModify() {
+  let a
+
+  app.del(a)
+}
+
 const myImportantLogic = () => {
   console.log("making sure it's there");
 };

--- a/transforms/__testfixtures__/v4-deprecated-signatures/delete.output.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/delete.output.ts
@@ -4,6 +4,18 @@ const app = express();
 
 app.get("/", (req, res) => {});
 
+app.delete([""],() => {
+  myImportantLogic();
+});
+
+app.delete([],() => {
+  myImportantLogic();
+});
+
+app.delete(/d/,() => {
+  myImportantLogic();
+});
+
 app.del(() => {
   myImportantLogic();
 });

--- a/transforms/__testfixtures__/v4-deprecated-signatures/delete.output.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/delete.output.ts
@@ -3,6 +3,15 @@ import express from "express";
 const app = express();
 
 app.get("/", (req, res) => {});
+
+app.del(() => {
+  myImportantLogic();
+});
+
+app.del(function () {
+  myImportantLogic();
+});
+
 app.delete("/old", () => {
   myImportantLogic();
 });

--- a/transforms/__testfixtures__/v4-deprecated-signatures/json.input.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/json.input.ts
@@ -2,6 +2,20 @@ import express from "express";
 
 const app = express();
 
+app.get("/json", function (...arg) {
+    const [, res] = arg
+    res.json();
+});
+
+app.get("/json", function (...arg) {
+    const [, res] = arg
+    res.json({ user: "Username", isValid: true }, 200);
+});
+
+app.get("/json", function (req, res) {
+    res.json();
+});
+
 app.get("/json", function (req, res) {    
     res.json({ user: "Username", isValid: true }, 200);
 });

--- a/transforms/__testfixtures__/v4-deprecated-signatures/json.output.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/json.output.ts
@@ -2,6 +2,20 @@ import express from "express";
 
 const app = express();
 
+app.get("/json", function (...arg) {
+    const [, res] = arg
+    res.json();
+});
+
+app.get("/json", function (...arg) {
+    const [, res] = arg
+    res.status(200).json({ user: "Username", isValid: true });
+});
+
+app.get("/json", function (req, res) {
+    res.json();
+});
+
 app.get("/json", function (req, res) {    
     res.status(200).json({ user: "Username", isValid: true });
 });

--- a/transforms/__testfixtures__/v4-deprecated-signatures/jsonp.input.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/jsonp.input.ts
@@ -2,6 +2,10 @@ import express from "express";
 
 const app = express();
 
+app.get("/json", function (req, res) {
+    res.json();
+});
+
 app.get("/jsonp", function (req, res) {
     res.jsonp({ user: "Username", isValid: true }, 200);
 });

--- a/transforms/__testfixtures__/v4-deprecated-signatures/jsonp.output.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/jsonp.output.ts
@@ -2,6 +2,10 @@ import express from "express";
 
 const app = express();
 
+app.get("/json", function (req, res) {
+    res.json();
+});
+
 app.get("/jsonp", function (req, res) {
     res.status(200).jsonp({ user: "Username", isValid: true });
 });

--- a/transforms/__testfixtures__/v4-deprecated-signatures/redirect.input.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/redirect.input.ts
@@ -3,6 +3,20 @@ import { redirect } from "somelibrary";
 
 const app = express();
 
+app.get("/", function (...arg) {
+  const [, res] = arg
+  res.redirect();
+});
+
+app.get("/", function (...arg) {
+  const [, res] = arg
+  res.redirect("/other-page", 301);
+});
+
+app.get("/", function (req, res) {
+  res.redirect();
+});
+
 app.get("/", function (req, res) {
   res.redirect("/other-page", 301);
 });

--- a/transforms/__testfixtures__/v4-deprecated-signatures/redirect.output.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/redirect.output.ts
@@ -3,6 +3,20 @@ import { redirect } from "somelibrary";
 
 const app = express();
 
+app.get("/", function (...arg) {
+  const [, res] = arg
+  res.redirect();
+});
+
+app.get("/", function (...arg) {
+  const [, res] = arg
+  res.redirect(301, "/other-page");
+});
+
+app.get("/", function (req, res) {
+  res.redirect();
+});
+
 app.get("/", function (req, res) {
   res.redirect(301, "/other-page");
 });

--- a/transforms/__testfixtures__/v4-deprecated-signatures/send-file.input.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/send-file.input.ts
@@ -23,6 +23,14 @@ const sharedSendFile = (res, next, fileName) => {
 }
 
 app.get('/file/:name', (req, res, next) => {
+  res.sendfile()
+})
+
+app.get('/file/:name', (req, res, next) => {
+  res.sendfile("file.txt")
+})
+
+app.get('/file/:name', (req, res, next) => {
   const fileName = req.params.name
 
   res.sendfile(fileName, options, (err) => {

--- a/transforms/__testfixtures__/v4-deprecated-signatures/send-file.output.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/send-file.output.ts
@@ -23,6 +23,14 @@ const sharedSendFile = (res, next, fileName) => {
 }
 
 app.get('/file/:name', (req, res, next) => {
+  res.sendFile()
+})
+
+app.get('/file/:name', (req, res, next) => {
+  res.sendFile("file.txt")
+})
+
+app.get('/file/:name', (req, res, next) => {
   const fileName = req.params.name
 
   res.sendFile(fileName, options, (err) => {

--- a/transforms/__testfixtures__/v4-deprecated-signatures/send.input.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/send.input.ts
@@ -2,6 +2,20 @@ import express from "express";
 
 const app = express();
 
+app.get("/send", function (...arg) {
+    const [, res] = arg
+    res.send();
+});
+
+app.get("/send", function (...arg) {
+    const [, res] = arg
+    res.send(200, true);
+});
+
+app.get("/send", function (req, res) {
+    res.send();
+});
+
 app.get("/send", function (req, res) {
     res.send(200, { hello: "world" });
 });

--- a/transforms/__testfixtures__/v4-deprecated-signatures/send.output.ts
+++ b/transforms/__testfixtures__/v4-deprecated-signatures/send.output.ts
@@ -2,6 +2,20 @@ import express from "express";
 
 const app = express();
 
+app.get("/send", function (...arg) {
+    const [, res] = arg
+    res.send();
+});
+
+app.get("/send", function (...arg) {
+    const [, res] = arg
+    res.status(200).send(true);
+});
+
+app.get("/send", function (req, res) {
+    res.send();
+});
+
 app.get("/send", function (req, res) {
     res.status(200).send({ hello: "world" });
 });

--- a/transforms/v4-deprecated-signatures.ts
+++ b/transforms/v4-deprecated-signatures.ts
@@ -104,7 +104,11 @@ export default function transformer(file: FileInfo, _api: API): string {
     .map((path) => {
       const pathArguments = path.node.arguments
 
-      if (pathArguments[0].type === 'ArrowFunctionExpression' || pathArguments[0].type === 'FunctionExpression')
+      if (
+        pathArguments[0].type !== 'RegExpLiteral' &&
+        pathArguments[0].type !== 'StringLiteral' &&
+        pathArguments[0].type !== 'ArrayExpression'
+      )
         return path
 
       if (path.node.callee.type === 'MemberExpression' && path.node.callee.property.type === 'Identifier') {


### PR DESCRIPTION
I found a bug in res.del, because if its first argument is a function, we shouldn't modify it to be res.delete.

And I added more tests to ensure that more cases are covered.