### PR TITLE
Fix broken Contributing Guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ The Express.js project welcomes all constructive contributions. Contributions ta
 from code for bug fixes and enhancements, to additions and fixes to documentation, additional
 tests, triaging incoming pull requests and issues, and more!
 
-See the [Contributing Guide](https://github.com/expressjs/express/blob/master/Contributing.md) for more technical details on contributing.
+See the [Contributing Guide](https://github.com/expressjs/codemod/blob/main/CONTRIBUTING.md) for more technical details on contributing.
+
 
 ## License
 


### PR DESCRIPTION
<!--
This PR fixes a broken link to the Contributing Guide in README.md.

The link previously pointed to the Express repository.
It now correctly points to the Contributing Guide in this repository.

Fixes #12


-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
