### PR TITLE
fix(codemod.yaml): correct package name format for v5 migration recipe

### DIFF
--- a/codemods/v5-migration-recipe/codemod.yaml
+++ b/codemods/v5-migration-recipe/codemod.yaml
@@ -1,5 +1,5 @@
 schema_version: "1.0"
-name: "@expressjs/v5/migration-recipe"
+name: "@expressjs/v5-migration-recipe"
 version: "1.0.0"
 description: This codemod migration recipe helps you update your Express.js v4 applications to be compatible with Express.js v5 by addressing deprecated APIs.
 author: bjohansebas (Sebastian Beltran)


### PR DESCRIPTION
see https://github.com/expressjs/codemod/actions/runs/20963670920 
<img width="1017" height="149" alt="imagen" src="https://github.com/user-attachments/assets/96c62743-7f0f-439d-a130-4abd12dbbf73" />
